### PR TITLE
fix: GitHub Actions cronスケジュールを一時停止

### DIFF
--- a/.github/workflows/check_new_videos.yml
+++ b/.github/workflows/check_new_videos.yml
@@ -1,8 +1,8 @@
 name: YouTube Summary Notifier
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  # schedule:
+  #   - cron: '*/5 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- 5分間隔のcronスケジュールをコメントアウトして一時停止
- 手動実行（workflow_dispatch）は維持

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)